### PR TITLE
Adiciona agregador automático de pesquisas (issue #4)

### DIFF
--- a/ATUALIZANDO_PESQUISAS.md
+++ b/ATUALIZANDO_PESQUISAS.md
@@ -66,23 +66,36 @@ python src/simulation_v2.py
 
 ---
 
-## Agregando múltiplas pesquisas
+## Agregando múltiplas pesquisas (automático)
 
-Se você quiser usar a **média de várias pesquisas**, calcule manualmente e coloque no CSV:
+Agora você pode agregar pesquisas automaticamente com o script `src/agregar_pesquisas.py`.
 
-| Pesquisa | Lula | Flávio |
-|---|---|---|
-| Datafolha | 38% | 27% |
-| Quaest | 36% | 28% |
-| PoderData | 37% | 26% |
-| **Média** | **37%** | **27%** |
-
-Coloque a média no CSV:
+### 1) Monte um CSV com uma linha por instituto
 
 ```csv
-candidato,intencao_voto_pct,desvio_padrao_pct,fonte,data
-Lula,37.0,2.0,Agregado (Datafolha + Quaest + PoderData),2026-02-20
+candidato,intencao_voto_pct,desvio_padrao_pct,instituto,data,amostra
+Lula,38.0,2.0,Datafolha,2026-02-18,2000
+Lula,36.0,2.0,Quaest,2026-02-19,2500
+Lula,37.0,2.0,PoderData,2026-02-20,2200
+Flávio Bolsonaro,27.0,2.0,Datafolha,2026-02-18,2000
 ...
+```
+
+### 2) Rode a agregação
+
+```bash
+python src/agregar_pesquisas.py --input data/pesquisas_exemplo_multiplas.csv --output data/pesquisas.csv
+```
+
+O script aplica:
+- Média ponderada por recência (`exp(-dias/7)`)
+- Desvio agregado: `sqrt(sigma_medio² + sigma_entre_institutos²)`
+- Detecção de outliers por z-score (limite padrão = 2)
+
+### 3) (Opcional) remover outliers automaticamente
+
+```bash
+python src/agregar_pesquisas.py --input data/pesquisas_exemplo_multiplas.csv --output data/pesquisas.csv --remove-outliers
 ```
 
 ---

--- a/data/pesquisas_exemplo_multiplas.csv
+++ b/data/pesquisas_exemplo_multiplas.csv
@@ -1,5 +1,13 @@
-candidato,intencao_voto_pct,desvio_padrao_pct,fonte,data
-Lula,37.0,2.0,Agregado (Datafolha 38% + Quaest 36% + PoderData 37%),2026-02-20
-Flávio Bolsonaro,27.0,2.0,Agregado (Datafolha 27% + Quaest 28% + PoderData 26%),2026-02-20
-Outros,21.0,2.0,Agregado (Datafolha 20% + Quaest 21% + PoderData 22%),2026-02-20
-Brancos/Nulos,15.0,2.0,Agregado (Datafolha 15% + Quaest 15% + PoderData 15%),2026-02-20
+candidato,intencao_voto_pct,desvio_padrao_pct,instituto,data,amostra
+Lula,38.0,2.0,Datafolha,2026-02-18,2000
+Flávio Bolsonaro,27.0,2.0,Datafolha,2026-02-18,2000
+Outros,20.0,2.0,Datafolha,2026-02-18,2000
+Brancos/Nulos,15.0,2.0,Datafolha,2026-02-18,2000
+Lula,36.0,2.0,Quaest,2026-02-19,2500
+Flávio Bolsonaro,28.0,2.0,Quaest,2026-02-19,2500
+Outros,21.0,2.0,Quaest,2026-02-19,2500
+Brancos/Nulos,15.0,2.0,Quaest,2026-02-19,2500
+Lula,37.0,2.0,PoderData,2026-02-20,2200
+Flávio Bolsonaro,26.0,2.0,PoderData,2026-02-20,2200
+Outros,22.0,2.0,PoderData,2026-02-20,2200
+Brancos/Nulos,15.0,2.0,PoderData,2026-02-20,2200

--- a/src/agregar_pesquisas.py
+++ b/src/agregar_pesquisas.py
@@ -1,0 +1,213 @@
+"""Agregador de pesquisas eleitorais por candidato.
+
+Lê múltiplas pesquisas (uma linha por instituto), calcula média ponderada por
+recência e ajusta o desvio padrão incluindo divergência entre institutos.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+import pandas as pd
+
+COLUNAS_OBRIGATORIAS = {
+    "candidato",
+    "intencao_voto_pct",
+    "desvio_padrao_pct",
+    "instituto",
+    "data",
+    "amostra",
+}
+
+
+def validar_csv(df: pd.DataFrame) -> None:
+    faltantes = COLUNAS_OBRIGATORIAS - set(df.columns)
+    if faltantes:
+        raise ValueError(f"Colunas faltando no CSV: {sorted(faltantes)}")
+
+
+def calcular_pesos_temporais(datas: pd.Series, data_referencia: pd.Timestamp) -> np.ndarray:
+    dias_atras = (data_referencia - datas).dt.days.clip(lower=0)
+    return np.exp(-dias_atras / 7.0)
+
+
+def desvio_entre_institutos(valores: np.ndarray, pesos: np.ndarray) -> float:
+    media = np.average(valores, weights=pesos)
+    variancia = np.average((valores - media) ** 2, weights=pesos)
+    return float(np.sqrt(max(variancia, 0.0)))
+
+
+def _linhas_outlier(
+    grupo: pd.DataFrame,
+    media_ponderada: float,
+    sigma_entre: float,
+    limite_z: float,
+) -> pd.DataFrame:
+    if len(grupo) < 2 or sigma_entre <= 0:
+        return grupo.iloc[0:0].copy()
+
+    z_scores = (grupo["intencao_voto_pct"] - media_ponderada).abs() / sigma_entre
+    outliers = grupo.loc[z_scores > limite_z].copy()
+    outliers["z_score"] = z_scores.loc[outliers.index]
+    return outliers
+
+
+def agregar_pesquisas_dataframe(
+    df: pd.DataFrame,
+    remover_outliers: bool = False,
+    limite_z: float = 2.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Agrega pesquisas por candidato e retorna (agregado, outliers)."""
+    validar_csv(df)
+
+    base = df.copy()
+    base["data"] = pd.to_datetime(base["data"], errors="raise")
+    data_referencia = base["data"].max()
+
+    resultados = []
+    outliers_detectados = []
+
+    for candidato, grupo_original in base.groupby("candidato", sort=True):
+        grupo = grupo_original.copy()
+        outliers_candidato = []
+
+        while True:
+            pesos = calcular_pesos_temporais(grupo["data"], data_referencia)
+            media_votos = float(np.average(grupo["intencao_voto_pct"], weights=pesos))
+            sigma_medio = float(np.average(grupo["desvio_padrao_pct"], weights=pesos))
+            sigma_entre = desvio_entre_institutos(grupo["intencao_voto_pct"].to_numpy(), pesos)
+            sigma_agregado = float(np.sqrt(sigma_medio**2 + sigma_entre**2))
+
+            outliers = _linhas_outlier(grupo, media_votos, sigma_entre, limite_z)
+
+            if not outliers.empty:
+                outliers = outliers.assign(
+                    candidato=candidato,
+                    media_ponderada_pct=media_votos,
+                    sigma_entre_pct=sigma_entre,
+                )
+                outliers_candidato.append(outliers)
+
+            if outliers.empty or not remover_outliers:
+                break
+
+            grupo = grupo.drop(index=outliers.index)
+            if grupo.empty:
+                grupo = grupo_original.copy()
+                break
+
+        if outliers_candidato:
+            outliers_detectados.append(pd.concat(outliers_candidato, ignore_index=True))
+
+        resultados.append(
+            {
+                "candidato": candidato,
+                "intencao_voto_pct": media_votos,
+                "desvio_padrao_pct": sigma_agregado,
+                "n_pesquisas": int(len(grupo)),
+                "amostra_total": int(grupo["amostra"].sum()),
+                "data_referencia": data_referencia.date().isoformat(),
+            }
+        )
+
+    agregado_df = pd.DataFrame(resultados).sort_values("candidato").reset_index(drop=True)
+    outliers_df = (
+        pd.concat(outliers_detectados, ignore_index=True)
+        if outliers_detectados
+        else pd.DataFrame(
+            columns=[
+                "candidato",
+                "instituto",
+                "data",
+                "intencao_voto_pct",
+                "desvio_padrao_pct",
+                "amostra",
+                "z_score",
+                "media_ponderada_pct",
+                "sigma_entre_pct",
+            ]
+        )
+    )
+
+    return agregado_df, outliers_df
+
+
+def agregar_pesquisas_csv(
+    caminho_entrada: Path,
+    caminho_saida: Path,
+    remover_outliers: bool = False,
+    limite_z: float = 2.0,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    df = pd.read_csv(caminho_entrada)
+    agregado_df, outliers_df = agregar_pesquisas_dataframe(
+        df,
+        remover_outliers=remover_outliers,
+        limite_z=limite_z,
+    )
+
+    caminho_saida.parent.mkdir(parents=True, exist_ok=True)
+    agregado_df.to_csv(caminho_saida, index=False)
+
+    return agregado_df, outliers_df
+
+
+def _formatar_alertas(outliers_df: pd.DataFrame) -> Iterable[str]:
+    for _, linha in outliers_df.iterrows():
+        yield (
+            "⚠️ OUTLIER DETECTADO: "
+            f"{linha['instituto']} reporta {linha['candidato']} com "
+            f"{linha['intencao_voto_pct']:.2f}% "
+            f"(média: {linha['media_ponderada_pct']:.2f}% ± {linha['sigma_entre_pct']:.2f}pp, "
+            f"z={linha['z_score']:.2f})"
+        )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Agrega pesquisas eleitorais por candidato")
+    parser.add_argument("--input", default="data/pesquisas.csv", help="CSV de entrada")
+    parser.add_argument(
+        "--output",
+        default="data/pesquisas_agregadas.csv",
+        help="CSV agregado de saída",
+    )
+    parser.add_argument(
+        "--remove-outliers",
+        action="store_true",
+        help="Remove pesquisas outliers antes de calcular o agregado",
+    )
+    parser.add_argument(
+        "--z-threshold",
+        type=float,
+        default=2.0,
+        help="Limiar z-score para detecção de outliers",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    entrada = Path(args.input)
+    saida = Path(args.output)
+
+    agregado_df, outliers_df = agregar_pesquisas_csv(
+        caminho_entrada=entrada,
+        caminho_saida=saida,
+        remover_outliers=args.remove_outliers,
+        limite_z=args.z_threshold,
+    )
+
+    print(f"✅ Agregação concluída: {len(agregado_df)} candidatos processados")
+    print(f"📁 Arquivo gerado: {saida}")
+
+    if outliers_df.empty:
+        print("✅ Nenhum outlier detectado")
+    else:
+        for alerta in _formatar_alertas(outliers_df):
+            print(alerta)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agregar_pesquisas.py
+++ b/tests/test_agregar_pesquisas.py
@@ -1,0 +1,118 @@
+import pandas as pd
+
+from src.agregar_pesquisas import agregar_pesquisas_dataframe
+
+
+def test_agregacao_media_ponderada_recencia():
+    df = pd.DataFrame(
+        [
+            {
+                "candidato": "Lula",
+                "intencao_voto_pct": 38.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "Datafolha",
+                "data": "2026-02-18",
+                "amostra": 2000,
+            },
+            {
+                "candidato": "Lula",
+                "intencao_voto_pct": 36.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "Quaest",
+                "data": "2026-02-19",
+                "amostra": 2500,
+            },
+            {
+                "candidato": "Lula",
+                "intencao_voto_pct": 37.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "PoderData",
+                "data": "2026-02-20",
+                "amostra": 2200,
+            },
+        ]
+    )
+
+    agregado, outliers = agregar_pesquisas_dataframe(df)
+
+    linha_lula = agregado.loc[agregado["candidato"] == "Lula"].iloc[0]
+
+    assert 36.9 < linha_lula["intencao_voto_pct"] < 37.1
+    assert linha_lula["desvio_padrao_pct"] > 2.0
+    assert linha_lula["n_pesquisas"] == 3
+    assert outliers.empty
+
+
+def test_detecta_outlier_sem_remover():
+    df = pd.DataFrame(
+        [
+            {
+                "candidato": "Candidato X",
+                "intencao_voto_pct": 31.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "I1",
+                "data": "2026-02-18",
+                "amostra": 2000,
+            },
+            {
+                "candidato": "Candidato X",
+                "intencao_voto_pct": 32.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "I2",
+                "data": "2026-02-19",
+                "amostra": 2000,
+            },
+            {
+                "candidato": "Candidato X",
+                "intencao_voto_pct": 45.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "I3",
+                "data": "2026-02-20",
+                "amostra": 2000,
+            },
+        ]
+    )
+
+    _, outliers = agregar_pesquisas_dataframe(df, limite_z=1.2)
+
+    assert len(outliers) == 1
+    assert outliers.iloc[0]["instituto"] == "I3"
+
+
+def test_remove_outlier_recalcula_agregado():
+    df = pd.DataFrame(
+        [
+            {
+                "candidato": "Candidato X",
+                "intencao_voto_pct": 31.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "I1",
+                "data": "2026-02-18",
+                "amostra": 2000,
+            },
+            {
+                "candidato": "Candidato X",
+                "intencao_voto_pct": 32.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "I2",
+                "data": "2026-02-19",
+                "amostra": 2000,
+            },
+            {
+                "candidato": "Candidato X",
+                "intencao_voto_pct": 45.0,
+                "desvio_padrao_pct": 2.0,
+                "instituto": "I3",
+                "data": "2026-02-20",
+                "amostra": 2000,
+            },
+        ]
+    )
+
+    agregado, outliers = agregar_pesquisas_dataframe(df, remover_outliers=True, limite_z=1.2)
+
+    linha = agregado.iloc[0]
+
+    assert len(outliers) == 1
+    assert linha["n_pesquisas"] == 2
+    assert linha["intencao_voto_pct"] < 33


### PR DESCRIPTION
### Motivation

- Automatizar a agregação de múltiplas pesquisas por candidato para evitar cálculos manuais ao atualizar o CSV. 
- Aplicar ponderação temporal para valorizar pesquisas mais recentes, ajustar a incerteza considerando discrepância entre institutos e detectar outliers automaticamente.

### Description

- Adicionado `src/agregar_pesquisas.py` com funções para validar o CSV, calcular `peso = exp(-dias_atras/7)`, computar `sigma_agregado = sqrt(sigma_medio**2 + sigma_entre_institutos**2)`, detectar outliers por z-score e CLI com `--input`, `--output`, `--remove-outliers` e `--z-threshold`.
- A função principal `agregar_pesquisas_dataframe` retorna o DataFrame agregado e um DataFrame de outliers, e `agregar_pesquisas_csv` grava o CSV de saída.
- Atualizado `data/pesquisas_exemplo_multiplas.csv` para o formato com colunas `instituto` e `amostra` (uma linha por instituto) e ajustada a documentação em `ATUALIZANDO_PESQUISAS.md` com instruções de uso.
- Adicionados testes em `tests/test_agregar_pesquisas.py` cobrindo média ponderada por recência, detecção de outliers e recálculo com remoção de outliers.

### Testing

- Executei `PYTHONPATH=. pytest -q` e todos os testes automatizados passaram (`5 passed`).
- Os novos testes em `tests/test_agregar_pesquisas.py` cobrem agregação temporal, detecção de outliers e remoção automática e foram incluídos na suíte de testes existente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69957bfaba108331bebcfce39a411cc1)