### PR TITLE
feat(io): add report.py with PDF and CSV output consuming SimulationResult

### DIFF
--- a/src/io/report.py
+++ b/src/io/report.py
@@ -255,7 +255,9 @@ def generate_pdf(result: SimulationResult, output_dir: Path) -> Path:
         - Overall second-round victory probabilities
 
     Args:
-        result:     Completed SimulationResult.
+        result:     Completed SimulationResult. result.pv and result.p2v
+                    must be in 0–1 scale — this function multiplies by 100
+                    for display. See issue #23.
         output_dir: Directory to write the PDF into (created if absent).
 
     Returns:


### PR DESCRIPTION
## O que este PR faz
Cria src/io/report.py com as funções de geração de PDF e CSV migradas
de simulation_v2.py. Ambas recebem SimulationResult como parâmetro.
Nomes de arquivo de output usam timestamp ISO 8601 — nenhum arquivo
gerado inclui número de versão no nome.

## Por que esta mudança é necessária
Sprint 2 — camada de I/O. relatorio_pdf() em simulation_v2.py lê
globals diretamente. Migrar para report.py com SimulationResult como
parâmetro isola a geração de output da lógica de simulação.

## Como testar
python -c "from src.io.report import generate_pdf, save_csvs; print('OK')"
generate_pdf() assume pv e p2v em escala 0–1. Ver issue #23 antes de integrar
com feat/core-simulation-engine.

## Checklist DoD
- [x] Nenhuma variável global introduzida
- [x] Nomes de output sem número de versão
- [x] Type hints e docstrings em funções públicas
- [x] CI passa
- [x] CHANGELOG.md atualizado