### PR TITLE
feat(core): migrate polymarket_edge and construir_modelo

### DIFF
--- a/src/core/bayesian.py
+++ b/src/core/bayesian.py
@@ -1,0 +1,109 @@
+"""
+Bayesian MCMC model for brazil-election-montecarlo.
+
+This module is the only place in src/core/ where PyMC is imported. It is called exclusively when ``config.use_bayesian is True``.
+
+All other simulation paths use the Dirichlet frequentist sampler in ``src.core.simulation``, which is ~60 s faster per run.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pymc as pm
+import arviz as az
+
+from src.core.config import PollData, SimulationConfig
+from src.core.simulation import distribuir_indecisos, _calcular_desvio_ajustado
+from datetime import date
+
+
+def construir_modelo(
+    config: SimulationConfig,
+    poll_data: PollData,
+) -> az.InferenceData:
+    """
+    Build and sample a Bayesian Dirichlet model of first-round vote shares.
+
+    Uses PyMC with a Dirichlet prior whose concentration parameters are derived from the aggregated poll data.  Undecided voters are redistributed before parameterising the prior, using the same logic as the frequentist path in :func:`~src.core.simulation.simular_primeiro_turno`.
+
+    This function should only be called when ``config.use_bayesian is True``.
+    The caller (``src.cli`` or ``src.core.simulation``) is responsible for that guard — this module does not check it.
+
+    Parameters
+    ----------
+    config:
+        Simulation configuration.  Uses ``seed`` and ``election_date``.``n_sim`` is not used here; MCMC draw count is fixed at 10 000 draws × 4 chains = 40 000 posterior samples to match the
+        frequentist default.
+    poll_data:
+        Aggregated poll data produced by ``src.io.loader.load_polls``.
+
+    Returns
+    -------
+    az.InferenceData
+        ArviZ InferenceData object containing the posterior trace.
+        Pass to ``az.summary()`` or use ``.posterior["votos_proporcao"]`` to extract samples.
+
+    Raises
+    ------
+    ValueError
+        If any effective vote share is NaN or <= 0 after undecided redistribution, which would cause Dirichlet initialisation to fail.
+
+    Notes
+    -----
+    The concentration factor is computed as ``100 / desvio_ajustado``, matching the frequentist Dirichlet parameterisation.  Higher desvio (more uncertainty) → lower concentration → wider posterior.
+    """
+    candidatos = poll_data.candidatos
+    votos_media = poll_data.votos_media.copy()
+    rejeicao = poll_data.rejeicao
+    desvio_base = poll_data.desvio_base
+    indecisos = poll_data.indecisos
+
+    # ── Temporal uncertainty adjustment ───────────────────────────────────────
+    desvio = _calcular_desvio_ajustado(desvio_base, config.election_date, date.today())
+
+    # ── Undecided voter redistribution ────────────────────────────────────────
+    votos_efetivos = votos_media.copy()
+    if indecisos > 0:
+        votos_efetivos, _ = distribuir_indecisos(
+            votos_media, indecisos, rejeicao, candidatos
+        )
+
+    # ── Sanity checks (Dirichlet requires all alpha > 0) ──────────────────────
+    if np.any(np.isnan(votos_efetivos)):
+        raise ValueError(
+            f"votos_media contains NaN after undecided redistribution: "
+            f"{list(zip(candidatos, votos_efetivos))}\n"
+            "Check the CSV for missing or invalid intencao_voto_pct values."
+        )
+    if np.any(votos_efetivos <= 0):
+        bad = [candidatos[i] for i, v in enumerate(votos_efetivos) if v <= 0]
+        raise ValueError(
+            f"Candidates with zero or negative vote share after redistribution: {bad}\n"
+            "Dirichlet requires all alpha parameters > 0."
+        )
+
+    # ── PyMC model ────────────────────────────────────────────────────────────
+    fator_concentracao = 100.0 / desvio
+    alphas = votos_efetivos * fator_concentracao
+
+    with pm.Model():
+        votos_proporcao = pm.Dirichlet(
+            "votos_proporcao",
+            a=alphas,
+            shape=len(candidatos),
+        )
+        for i, cand in enumerate(candidatos):
+            var_name = (
+                cand.replace(" ", "_").replace("/", "_").replace("-", "_")
+            )
+            pm.Deterministic(var_name, votos_proporcao[i] * 100)
+
+        trace = pm.sample(
+            draws=10_000,
+            tune=2_000,
+            chains=4,
+            return_inferencedata=True,
+            random_seed=config.seed if config.seed is not None else 42,
+        )
+
+    return trace

--- a/src/core/polymarket.py
+++ b/src/core/polymarket.py
@@ -1,0 +1,120 @@
+"""
+Polymarket edge calculation for brazil-election-montecarlo.
+
+Pure functions: no I/O, no global state, no side effects.
+All inputs arrive as parameters; all outputs are returned as dicts.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def polymarket_edge(
+    df1: pd.DataFrame,
+    threshold: float,
+    market_prob: float,
+    candidate: str | None = None,
+) -> dict:
+    """
+    Compute the edge between the model and a Polymarket margin market.
+
+    If ``candidate`` is provided, the probability is conditioned on that
+    candidate leading — i.e. ``P(margem_<candidate> > threshold)``, which
+    is positive only in simulations where that candidate finishes first.
+    Otherwise the unsigned ``margem_1t`` column is used (absolute gap
+    between 1st and 2nd place), regardless of who leads.
+
+    Parameters
+    ----------
+    df1:
+        First-round simulation results DataFrame, as returned by
+        ``src.core.simulation.simular_primeiro_turno()``.
+        Must contain ``"margem_1t"`` (unconditional) or
+        ``"margem_<candidate>"`` (conditional) columns.
+    threshold:
+        Margin threshold in percentage points (e.g. ``15.0`` for the
+        Lula >15pp market).
+    market_prob:
+        Polymarket implied probability as a decimal in [0, 1]
+        (e.g. ``0.55`` for a market priced at 55 cents).
+    candidate:
+        Optional candidate name to condition on (e.g. ``"Lula"``).
+        When supplied, only simulations where that candidate is leading
+        contribute to ``model_prob``.
+
+    Returns
+    -------
+    dict
+        Keys:
+
+        * ``model_prob``     – ``P(margin > threshold)`` from the model, in [0, 1].
+        * ``market_prob``    – Echo of the ``market_prob`` argument.
+        * ``edge``           – ``model_prob − market_prob`` (positive = model
+          favours YES; actionable when >= 0.12 in the primary entry window).
+        * ``kelly_fraction`` – Half-Kelly stake as a fraction of bankroll;
+          0.0 when ``edge <= 0``.
+        * ``threshold_pp``   – Echo of ``threshold``.
+        * ``candidate``      – Echo of ``candidate`` (or ``None``).
+        * ``n_sim``          – Number of simulations used.
+
+    Raises
+    ------
+    KeyError
+        If the required margin column is missing from ``df1``.
+    ValueError
+        If ``market_prob`` is not in (0, 1].
+
+    Notes
+    -----
+    Half-Kelly formula::
+
+        b = (1 / market_prob) - 1
+        full_kelly = (b * model_prob - (1 - model_prob)) / b
+        kelly_fraction = max(0, full_kelly) / 2
+
+    The Lula overall-winner edge is generally not actionable because
+    Polymarket prices political and legal risk outside the model's scope.
+    The 5–10pp margin market is the most reliable signal.
+    """
+    if not (0.0 < market_prob <= 1.0):
+        raise ValueError(
+            f"market_prob must be in (0, 1], got {market_prob}"
+        )
+
+    if candidate is not None:
+        col = f"margem_{candidate}"
+        if col not in df1.columns:
+            raise KeyError(
+                f"Column '{col}' not found in df1. "
+                f"Check that simular_primeiro_turno() was called with this candidate "
+                f"or verify the spelling: {list(df1.columns)}"
+            )
+        series = df1[col]  # signed: positive only when candidate is leading
+    else:
+        if "margem_1t" not in df1.columns:
+            raise KeyError(
+                "Column 'margem_1t' not found in df1. "
+                "Ensure simular_primeiro_turno() populated the margin columns."
+            )
+        series = df1["margem_1t"]
+
+    model_prob = float((series > threshold).mean())
+    edge = model_prob - market_prob
+
+    if edge > 0 and market_prob < 1.0:
+        b = (1.0 / market_prob) - 1.0
+        full_kelly = (b * model_prob - (1.0 - model_prob)) / b
+        kelly_fraction = max(0.0, full_kelly / 2.0)
+    else:
+        kelly_fraction = 0.0
+
+    return {
+        "model_prob":      round(model_prob, 4),
+        "market_prob":     round(market_prob, 4),
+        "edge":            round(edge, 4),
+        "kelly_fraction":  round(kelly_fraction, 4),
+        "threshold_pp":    threshold,
+        "candidate":       candidate,
+        "n_sim":           len(df1),
+    }


### PR DESCRIPTION
## Changes
- `src/core/polymarket.py`: `polymarket_edge()` extraída como função pura.
  Nenhum global. Adiciona validação de `market_prob` e mensagem de erro mais descritiva no `KeyError`.
- `src/core/bayesian.py`: `construir_modelo()` recebe `config` e `poll_data` como parâmetros. Único arquivo em `src/core/` que importa `pymc`/`arviz`, isolamento intencional para não penalizar o path frequentista.

## Checklist
- [x] Nenhuma variável `global` introduzida
- [x] Type hints em todos os parâmetros públicos
- [x] Docstrings NumPy em todas as funções públicas
- [x] Nenhum import de `matplotlib` ou `streamlit` em `src/core/`
- [x] `simulation_v2.py` intocado
- [ ] Testes unitários — pendente Test Engineer (test/polymarket-unit-tests)

## Blocking
`feat/io-report-output` pode consumir `polymarket_edge` após merge.